### PR TITLE
Fix for TypeScript-Support with @types/leaflet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ var poly1 = [
     [24.5, 121.9],
     [24, 121.9]
 ];
-L.polygon(poly1, {fill:'url(image.gif)'}).addTo(map);
+L.polygon(poly1, {fillImage:'url(image.gif)'}).addTo(map);
 ```

--- a/example/index.html
+++ b/example/index.html
@@ -27,7 +27,7 @@
             [24.5, 121.9],
             [24, 121.9]
         ];
-        L.polygon(poly1, {fill:'url(image.gif)'}).addTo(map);
+        L.polygon(poly1, {fillImage:'url(image.gif)'}).addTo(map);
 
         var poly2 = [
             [24, 120],

--- a/leaflet-polygon.fillPattern.js
+++ b/leaflet-polygon.fillPattern.js
@@ -37,20 +37,16 @@ if (L.Browser.svg) {
                 path.setAttribute('stroke', 'none');
             }
 
-            if (options.fill) {
-                if (typeof(options.fill) == "string" &&
-                        options.fill.match(/^url\(/)) {
-                    // here what we add
-                    this.__fillPattern(layer);
-                }
-                else {
-                    path.setAttribute('fill', options.fillColor || options.color);
-                }
-                path.setAttribute('fill-opacity', options.fillOpacity);
-                path.setAttribute('fill-rule', options.fillRule || 'evenodd');
-            } else {
-                path.setAttribute('fill', 'none');
+            if (options.fillImage && typeof(options.fillImage) == "string" &&
+                    options.fillImage.match(/^url\(/)) {
+                // here what we add
+                this.__fillPattern(layer);
             }
+            else {
+                path.setAttribute('fill', options.fillColor || options.color);
+            }
+            path.setAttribute('fill-opacity', options.fillOpacity);
+            path.setAttribute('fill-rule', options.fillRule || 'evenodd');
         },
 
         __fillPattern: function(layer) {
@@ -61,7 +57,7 @@ if (L.Browser.svg) {
                 this._defs = L.SVG.create('defs');
                 this._container.appendChild(this._defs);
             }
-            var _img_url = options.fill.substring(4, options.fill.length-1);
+            var _img_url = options.fillImage.substring(4, options.fillImage.length-1);
             var _ref_id = _img_url + (Math.random() * Math.pow(10, 17) + Math.random() * Math.pow(10, 17));
             _ref_id += new Date().getUTCMilliseconds();
             var _p = document.getElementById(_ref_id);

--- a/leaflet.d.ts
+++ b/leaflet.d.ts
@@ -1,0 +1,7 @@
+import { PolylineOptions } from "leaflet";
+
+declare module "leaflet" {
+  interface PolylineOptions {
+    fillImage?: string | undefined;
+  }
+}


### PR DESCRIPTION
Hey, thanks for your work, this was really helpful.

I use leaflet with TypeScript and in @types/leaflet, "fill" is declared as boolean, which is completely correct and should stay so, but that means that I cannot write the String "url(...)" to it. I solved that for my case by changing your code to use "fillImage" and adding this field to the PolylineOptions in a new .d.ts file in my project.
I'd like to contribute this to your code, but I don't know, if the way I did this is helpful or it should be done differently.
Another approach I'd like to suggest is putting this project on npm and adding an @types entry for it. But I'm not sure if that would work either, because leaflet plugins are a bit difficult to get them to work with typescript.